### PR TITLE
Fixed the deallocation of virtual objects

### DIFF
--- a/openvx/ago/ago_util.cpp
+++ b/openvx/ago/ago_util.cpp
@@ -3140,13 +3140,6 @@ AgoContext::~AgoContext()
 		agraph = next;
 	}
 
-	agoResetDataList(&dataList);
-	for (AgoData * data = graph_garbage_data; data;) {
-		AgoData * item = data;
-		data = data->next;
-		delete item;
-	}
-
 	for (AgoNode * node = graph_garbage_node; node;) {
 		AgoNode * item = node;
 		node = node->next;
@@ -3156,6 +3149,13 @@ AgoContext::~AgoContext()
 	for (AgoGraph * graph = graph_garbage_list; graph;) {
 		AgoGraph * item = graph;
 		graph = graph->next;
+		delete item;
+	}
+
+	agoResetDataList(&dataList);
+	for (AgoData * data = graph_garbage_data; data;) {
+		AgoData * item = data;
+		data = data->next;
 		delete item;
 	}
 


### PR DESCRIPTION
Now the graph destructor moves virtual data objects to context trash to be deleted when the context is deleted